### PR TITLE
Change seconds to ms in the report

### DIFF
--- a/load-test-timing.js
+++ b/load-test-timing.js
@@ -117,7 +117,7 @@ const action = async (context, data) => {
 
   const header = `
       <header>
-        <b># Iterations:</b> [${numIterations}] <b>Delay between requests:</b> [${delayBetweenRequests}s] <b>Run:</b> 
+        <b># Iterations:</b> [${numIterations}] <b>Delay between requests:</b> [${delayBetweenRequests}ms] <b>Run:</b> 
         [${runInParallel ? "in Parallel" : "Serially"}]
       </header>`;
 


### PR DESCRIPTION
Change seconds to ms in the report when displaying delayBetweenRequests currently it displays seconds but the actual unit is ms
# Iterations: [50] Delay between requests: [5000s] Run: [in Parallel]
                                                                           ___ ^___